### PR TITLE
fix the fallback boot entry

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -35,6 +35,12 @@ fi
 MOUNT_PATH=/frzr_root
 
 UEFI="-d /sys/firmware/efi/efivars"
+if [ $UEFI ]; then
+	EFI_DIR=${MOUNT_PATH}/boot/EFI/BOOT
+	if [ -d ${MOUNT_PATH}/boot/EFI/syslinux ]; then
+	    EFI_DIR=${MOUNT_PATH}/boot/EFI/syslinux
+	fi
+fi
 
 if ! mountpoint -q ${MOUNT_PATH}; then
 	MOUNT_PATH=/tmp/frzr_root
@@ -63,7 +69,7 @@ mkdir -p ${DEPLOY_PATH}
 if frzr-release > /dev/null; then
 	CURRENT=`frzr-release`
 
-	BOOT_CFG=${MOUNT_PATH}/boot/EFI/syslinux/syslinux.cfg
+	BOOT_CFG=${EFI_DIR}/syslinux.cfg
 	if [ ! -f $BOOT_CFG ]; then
 		BOOT_CFG=${MOUNT_PATH}/boot/syslinux/syslinux.cfg
 	fi
@@ -150,8 +156,7 @@ label ${NAME}
 kernel ../../${NAME}/vmlinuz-linux
 append root=LABEL=frzr_root rw rootflags=subvol=deployments/${NAME} quiet splash loglevel=3 rd.systemd.show_status=auto rd.udev.log_priority=3
 initrd ../../${NAME}/initramfs-linux.img
-" > ${MOUNT_PATH}/boot/EFI/syslinux/syslinux.cfg
-cp ${MOUNT_PATH}/boot/EFI/syslinux/syslinux.cfg ${MOUNT_PATH}/boot/EFI/BOOT/syslinux.cfg
+" > ${EFI_DIR}/syslinux.cfg
 else
 echo "
 default ${NAME}

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -151,6 +151,7 @@ kernel ../../${NAME}/vmlinuz-linux
 append root=LABEL=frzr_root rw rootflags=subvol=deployments/${NAME} quiet splash loglevel=3 rd.systemd.show_status=auto rd.udev.log_priority=3
 initrd ../../${NAME}/initramfs-linux.img
 " > ${MOUNT_PATH}/boot/EFI/syslinux/syslinux.cfg
+cp ${MOUNT_PATH}/boot/EFI/syslinux/syslinux.cfg ${MOUNT_PATH}/boot/EFI/BOOT/syslinux.cfg
 else
 echo "
 default ${NAME}

--- a/frzr-bootstrap
+++ b/frzr-bootstrap
@@ -83,6 +83,7 @@ if [ $UEFI ]; then
 
 	# for compatibility with some broken uefi implementations
 	mkdir -p ${MOUNT_PATH}/boot/EFI/BOOT
+	cp -r /usr/lib/syslinux/efi64/* ${MOUNT_PATH}/boot/EFI/BOOT/
 	cp /usr/lib/syslinux/efi64/syslinux.efi ${MOUNT_PATH}/boot/EFI/BOOT/bootx64.efi
 else
 	mkdir -p ${MOUNT_PATH}/boot/syslinux

--- a/frzr-bootstrap
+++ b/frzr-bootstrap
@@ -77,11 +77,6 @@ mount -t vfat ${PART1} ${MOUNT_PATH}/boot/
 
 if [ $UEFI ]; then
 	# setup basic syslinux configuration
-	mkdir -p ${MOUNT_PATH}/boot/EFI/syslinux
-	cp -r /usr/lib/syslinux/efi64/* ${MOUNT_PATH}/boot/EFI/syslinux
-	efibootmgr --create --disk ${DISK} --part 1 --loader /EFI/syslinux/syslinux.efi --label "frzr"
-
-	# for compatibility with some broken uefi implementations
 	mkdir -p ${MOUNT_PATH}/boot/EFI/BOOT
 	cp -r /usr/lib/syslinux/efi64/* ${MOUNT_PATH}/boot/EFI/BOOT/
 	cp /usr/lib/syslinux/efi64/syslinux.efi ${MOUNT_PATH}/boot/EFI/BOOT/bootx64.efi


### PR DESCRIPTION
my system forgets the boot entry if that drive is removed, and I found out the failback efi entry is not working (just take me to the UEFI settings). Copying everything under EFI/syslinux over seems to fixed the problem.

I'm very new to ChimeraOS so I'm not sure if this is the only place that needs updating (like updates or whatever). and really I think it might be a good idea for ChimeraOS to just use the default location for everything since its the only os on the drive anyway.