### PR TITLE
Allow custom boot paramenters in image

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -60,11 +60,12 @@ get_syslinux_cfg() {
 	local version=${1}
 	local prefix=${2}
 	local additional_initrd=${3}
+	local additional_arguments=${4}
 
 echo "default ${version}
 label ${version}
 kernel ${prefix}/${version}/vmlinuz-linux
-append root=LABEL=frzr_root rw rootflags=subvol=deployments/${version} quiet splash loglevel=3 rd.systemd.show_status=auto rd.udev.log_priority=3 ibt=off split_lock_detect=off
+append root=LABEL=frzr_root rw rootflags=subvol=deployments/${version} quiet splash loglevel=3 rd.systemd.show_status=auto rd.udev.log_priority=3 ${additional_arguments}
 initrd ${additional_initrd}${prefix}/${version}/initramfs-linux.img"
 
 }
@@ -240,7 +241,12 @@ main() {
 		ADDITIONAL_INITRD="${ADDITIONAL_INITRD}${PREFIX}/${NAME}/intel-ucode.img,"
 	fi
 
-	get_syslinux_cfg ${NAME} ${PREFIX} ${ADDITIONAL_INITRD} > ${BOOT_CFG}
+	ADDITIONAL_ARGUMENTS=""
+	if [ -e ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf ] ; then
+		ADDITIONAL_ARGUMENTS="$ADDITIONAL_ARGUMENTS $(cat ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf)"
+	fi
+
+	get_syslinux_cfg ${NAME} ${PREFIX} ${ADDITIONAL_INITRD} ${ADDITIONAL_ARGUMENTS} > ${BOOT_CFG}
 
 	rm -f ${MOUNT_PATH}/*.img.*
 


### PR DESCRIPTION
Since most arguments are tied to the kernel version in the image, we should be able to accomodate for that. For example an argument like `split_lock_detect=off` only makes sense for gaming images on kernel version 6.1 and after.

This will look inside the image for additional arguments to put into the bootloader configuration.

Arguments need to be written in a special file
(`/usr/lib/frzr.d/bootconfig.conf`) in a single line separated by spaces or one parameter per line. The contents of that file will be `cat`-ed to the current bootloader arguments.