### PR TITLE
Escape syslinux additional initrd and arguments

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -283,7 +283,7 @@ main() {
 		ADDITIONAL_ARGUMENTS="$ADDITIONAL_ARGUMENTS $(cat ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf)"
 	fi
 
-	get_syslinux_cfg ${NAME} ${PREFIX} ${ADDITIONAL_INITRD} ${ADDITIONAL_ARGUMENTS} > ${BOOT_CFG}
+	get_syslinux_cfg ${NAME} ${PREFIX} "${ADDITIONAL_INITRD}" "${ADDITIONAL_ARGUMENTS}" > ${BOOT_CFG}
 
 	rm -f ${MOUNT_PATH}/*.img.*
 


### PR DESCRIPTION
Escaping these arguments so when we have multiple values for `ADDITIONAL_INITRD` and/or `ADDITIONAL_ARGUMENTS` all values are passed to the syslinux.cfg.

I'm facing an issue where not all values on `usr/lib/frzr.d/bootconfig.conf` are being used because only the first one is considered, I believe this is due to the shell expansion and the function expecting only 4 arguments