### PR TITLE
Migration support

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -298,7 +298,7 @@ main() {
 			echo "Applying migration $(basename $m)"
 			unset -f post_install
 			. $m
-			post_install "${SUBVOL}"
+			post_install "${MOUNT_PATH}" "${SUBVOL}"
 			unset -f post_install
 		done
 	fi

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -291,8 +291,16 @@ main() {
 
 	echo "deployment complete; restart to boot into ${NAME}"
 
-	if command -v frzr-postupdate-script > /dev/null; then
-		frzr-postupdate-script
+	# Check if there are migrations available
+	if compgen -G "${SUBVOL}"/usr/lib/frzr.d/*.migration > /dev/null ; then
+		for m in "${SUBVOL}"/usr/lib/frzr.d/*.migration ;
+		do
+			echo "Applying migration $(basename $m)"
+			unset -f post_install
+			. $m
+			post_install "${SUBVOL}"
+			unset -f post_install
+		done
 	fi
 
 	umount -R ${MOUNT_PATH}


### PR DESCRIPTION
# Why
Look into #22 

# How
`frzr` will look into the recently installed image and run `.migration` files under `${SUBVOL}/usr/lib/frzr.d/`. Those are text files that can be read by bash and define functions to run in the current installation. The first argument of the function is the path for the `$MOUNT_PATH` and the second is `$SUBVOL` in case that is needed.

Note: Some inspiration is taken from pacman `.install` files.

Possible fucntions in a migration file:
Planning on adding `pre_install` and `post_install` functions. 