### PR TITLE
Add support for remote deployments

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -84,7 +84,6 @@ main() {
 	fi
 
 	FRZR_CHECK_UPDATE=0
-	FRZR_IMAGE_SOURCE=$1
 	FRZR_STEAM_PROGRESS=0
 	FRZR_SOURCE=""
 	FRZR_PARAMS=""
@@ -174,7 +173,7 @@ main() {
 		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
 		SUBVOL="${DEPLOY_PATH}/${NAME}"
 		IMG_FILE="/root/tmp_source/${FILE_NAME}"
-	elif [[ "$FRZR_IMAGE_SOURCE" == *".img.tar.xz" ]]; then
+	elif [[ "$FRZR_SOURCE" == *".img.tar.xz" ]]; then
 		FILE_NAME=$(basename ${FRZR_IMAGE_SOURCE})
 		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
 		SUBVOL="${DEPLOY_PATH}/${NAME}"

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -84,6 +84,7 @@ main() {
 	fi
 
 	FRZR_CHECK_UPDATE=0
+	FRZR_IMAGE_SOURCE=$1
 	FRZR_STEAM_PROGRESS=0
 	FRZR_SOURCE=""
 	FRZR_PARAMS=""
@@ -173,6 +174,11 @@ main() {
 		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
 		SUBVOL="${DEPLOY_PATH}/${NAME}"
 		IMG_FILE="/root/tmp_source/${FILE_NAME}"
+	elif [ "$FRZR_IMAGE_SOURCE" == *".img.tar.xz"* ]; then
+		FILE_NAME=$(basename ${FRZR_IMAGE_SOURCE})
+		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
+		SUBVOL="${DEPLOY_PATH}/${NAME}"
+		IMG_FILE=${FRZR_IMAGE_SOURCE}
 	else
 		REPO=$(echo "${SOURCE}" | cut -f 1 -d ':')
 		CHANNEL=$(echo "${SOURCE}" | cut -f 2 -d ':')

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -174,10 +174,10 @@ main() {
 		SUBVOL="${DEPLOY_PATH}/${NAME}"
 		IMG_FILE="/root/tmp_source/${FILE_NAME}"
 	elif [[ "$FRZR_SOURCE" == *".img.tar.xz" ]]; then
-		FILE_NAME=$(basename ${FRZR_IMAGE_SOURCE})
+		FILE_NAME=$(basename ${FRZR_SOURCE})
 		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
 		SUBVOL="${DEPLOY_PATH}/${NAME}"
-		IMG_FILE=${FRZR_IMAGE_SOURCE}
+		IMG_FILE=${FRZR_SOURCE}
 	else
 		REPO=$(echo "${SOURCE}" | cut -f 1 -d ':')
 		CHANNEL=$(echo "${SOURCE}" | cut -f 2 -d ':')

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -174,7 +174,7 @@ main() {
 		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
 		SUBVOL="${DEPLOY_PATH}/${NAME}"
 		IMG_FILE="/root/tmp_source/${FILE_NAME}"
-	elif [ "$FRZR_IMAGE_SOURCE" == *".img.tar.xz"* ]; then
+	elif [[ "$FRZR_IMAGE_SOURCE" == *".img.tar.xz" ]]; then
 		FILE_NAME=$(basename ${FRZR_IMAGE_SOURCE})
 		NAME=$(echo "${FILE_NAME}" | cut -f 1 -d '.')
 		SUBVOL="${DEPLOY_PATH}/${NAME}"


### PR DESCRIPTION
Tested using `sshfs` and in theory ftp or any other mountable shares should work as well.
- Allow remote deployment installations by using `frzr-deploy /path/to/remote/.img.tar.xz`
