### PR TITLE
Add frzr-initramfs and frzr-tweaks

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -293,7 +293,7 @@ main() {
 	
 	# Check if the FIRMWARE_OVERRIDE variable is set by the install media, if so enable firmware overrides
 	if [ -n ${FIRMWARE_OVERRIDE} ]; then
-		echo echo "export USE_FIRMWARE_OVERRIDES=1" > ${MOUNT_PATH}/etc/device-quirks.conf
+		echo "export USE_FIRMWARE_OVERRIDES=1" > ${MOUNT_PATH}/etc/device-quirks.conf
 	fi
 	
 	# Run frzr-tweaks to execute the device-quirks to be supplied by the deployed images

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -291,6 +291,11 @@ main() {
 	export SUBVOL
 	export NAME
 	
+	# Check if the FIRMWARE_OVERRIDE variable is set by the install media, if so enable firmware overrides
+	if [ -n ${FIRMWARE_OVERRIDE} ]; then
+		echo echo "export USE_FIRMWARE_OVERRIDES=1" > ${MOUNT_PATH}/etc/device-quirks.conf
+	fi
+	
 	# Run frzr-tweaks to execute the device-quirks to be supplied by the deployed images
 	frzr-tweaks
 

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -273,11 +273,6 @@ main() {
 	get_boot_cfg "${NAME}" "${AMD_UCODE}" "${INTEL_UCODE}" "${ADDITIONAL_ARGUMENTS}" > ${BOOT_CFG}
 	echo "default frzr.conf" > ${MOUNT_PATH}/boot/loader/loader.conf
 
-	rm -f ${MOUNT_PATH}/*.img.*
-
-	rm -rf /var/lib/pacman # undo frzr-unlock
-
-
 	# Check if there are migrations available
 	if compgen -G "${SUBVOL}"/usr/lib/frzr.d/*.migration > /dev/null ; then
 		for m in "${SUBVOL}"/usr/lib/frzr.d/*.migration ;
@@ -290,6 +285,16 @@ main() {
 			unset -f post_install
 		done
 	fi
+
+	# Run frzr-tweaks to execute the device-quirks to be supplied by the deployed images
+	frzr-tweaks "${MOUNT_PATH}" "${SUBVOL}" "${NAME}"
+
+	# Run frzr-initramfs to create mkinicpio.conf and build an initramfs
+	frzr-initramfs "${MOUNT_PATH}" "${SUBVOL}" "${NAME}"
+
+	rm -f ${MOUNT_PATH}/*.img.*
+
+	rm -rf /var/lib/pacman # undo frzr-unlock
 
 	echo "deployment complete; restart to boot into ${NAME}"
 

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -285,12 +285,17 @@ main() {
 			unset -f post_install
 		done
 	fi
-
+	
+	# Export variables to be used by child processes for frzr-tweaks and frzr-initramfs
+	export MOUNT_PATH
+	export SUBVOL
+	export NAME
+	
 	# Run frzr-tweaks to execute the device-quirks to be supplied by the deployed images
-	frzr-tweaks "${MOUNT_PATH}" "${SUBVOL}" "${NAME}"
+	frzr-tweaks
 
 	# Run frzr-initramfs to create mkinicpio.conf and build an initramfs
-	frzr-initramfs "${MOUNT_PATH}" "${SUBVOL}" "${NAME}"
+	frzr-initramfs
 
 	rm -f ${MOUNT_PATH}/*.img.*
 

--- a/frzr-initramfs
+++ b/frzr-initramfs
@@ -41,7 +41,6 @@ EOF
         echo "No deployment directory found"
         exit 1
     fi
-    exit 0
 else
     echo "We don't appear to be running from an arch install media"
 fi

--- a/frzr-initramfs
+++ b/frzr-initramfs
@@ -1,0 +1,109 @@
+#! /bin/bash
+
+if [ $EUID -ne 0 ]; then
+    echo "$(basename $0) must be run as root"
+    exit 1
+fi
+
+# If the script is being ran directly we will need to set the paths
+if [ -d /tmp/frzr_root ]; then
+    export MOUNT_PATH=$1
+    export SUBVOL=$2
+    export NAME=$3
+    
+    # Checking paths
+    echo "Checking installion info..."
+    echo "Root Mount:${MOUNT_PATH}"
+    echo "Subvolume Mount:${SUBVOL}"
+    echo "Deployment Name:${NAME}"
+else
+    # This is for running frzr-initramfs from the deployed system itself without frzr-deploy
+    export MOUNT_PATH=""
+    export SUBVOL=""
+fi
+
+if [ -d /tmp/frzr_root ]; then
+    
+    if [ -d "${SUBVOL}" ]; then
+        
+        cd ${SUBVOL}
+        # Mount necessary file systems
+        mount -t proc /proc proc/
+        mount -t sysfs /sys sys/
+        mount --rbind /dev dev/
+        
+        # Set R/W permissions
+        btrfs property set -fts ${SUBVOL} ro false
+	chroot ${SUBVOL} /bin/bash <<EOF
+# Commands to be ran in chroot
+
+### Create distro mkinitcpio preset
+echo '
+ALL_config="/etc/mkinitcpio.conf"
+ALL_kver="/boot/vmlinuz-linux"
+ALL_microcode=(/boot/*-ucode.img)
+
+PRESETS="default"
+
+default_image="/boot/initramfs-linux.img"
+' > /etc/mkinitcpio.d/\${NAME%%-*}.preset
+
+### Rebuild Initramfs with custom preset
+mkinitcpio -p \${NAME%%-*}
+EOF
+        # Set back to R/O permissions
+        btrfs property set -fts ${SUBVOL} ro true
+    else
+        echo "No deployment directory found"
+        exit 1
+    fi
+    exit 0
+else
+    echo "We don't appear to be running from an arch install media"
+fi
+# Build initramfs from within a deployed system
+if [ -d /frzr_root ]; then
+
+    ### Get Distro version and build
+    ID=`grep '^ID=' /etc/os-release | awk -F= '{ print $2 }' | sed s/\"//g`
+    
+    VERSIONID=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed s/\"//g`
+    
+    BUILDID=`grep '^BUILD_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed s/\"//g`
+    
+    BUILD="$ID"-"$VERSIONID"_"$BUILDID"
+    DEPLOYMENT_PATH="/frzr_root/deployments/$BUILD"
+    
+    # Get locked state
+    RELOCK=0
+    LOCK_STATE=$(btrfs property get -fts "$DEPLOYMENT_PATH")
+    if [[ $LOCK_STATE == *"ro=true"* ]]; then
+        btrfs property set -fts ${DEPLOYMENT_PATH} ro false
+        RELOCK=1
+    else
+        echo "Filesystem appears to be unlocked"
+    fi
+    
+    echo $BUILD
+
+    ### Create distro mkinitcpio preset
+    echo '
+ALL_config="/etc/mkinitcpio.conf"
+ALL_kver="/boot/'$BUILD'/vmlinuz-linux"
+ALL_microcode=(/boot/'$BUILD'/*-ucode.img)
+
+PRESETS="default"
+
+default_image="/boot/'$BUILD'/initramfs-linux.img"
+' > /etc/mkinitcpio.d/$ID.preset
+    
+    ### Rebuild Initramfs with custom preset
+    mkinitcpio -p $ID
+    
+    if [[ $RELOCK == 1 ]]; then
+       btrfs property set -fts ${DEPLOYMENT_PATH} ro true
+    else
+       # Move rebuilt images to the unlocked location if system was unlocked prior
+       cp /boot/$BUILD/* /boot
+    fi
+fi

--- a/frzr-initramfs
+++ b/frzr-initramfs
@@ -48,10 +48,18 @@ fi
 # Build initramfs from within a deployed system
 if [ -d /frzr_root ]; then
 
-    ### Get Distro version and build
-    ID=`grep '^ID=' /etc/os-release | awk -F= '{ print $2 }' | sed s/\"//g`
-    VERSIONID=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed s/\"//g`
-    BUILDID=`grep '^BUILD_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed s/\"//g`
+if [ -n "$SUBVOL" ]; then
+    ### Get Distro version and build from $SUBVOL/etc/os-release
+    ID=$(grep '^ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
+    VERSIONID=$(grep '^VERSION_ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
+    BUILDID=$(grep '^BUILD_ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
+else
+    ### Get Distro version and build from /etc/os-release
+    ID=$(grep '^ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
+    VERSIONID=$(grep '^VERSION_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
+    BUILDID=$(grep '^BUILD_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
+fi
+
     BUILD="$ID"-"$VERSIONID"_"$BUILDID"
     DEPLOYMENT_PATH="/frzr_root/deployments/$BUILD"
     

--- a/frzr-initramfs
+++ b/frzr-initramfs
@@ -5,7 +5,7 @@ if [ $EUID -ne 0 ]; then
     exit 1
 fi
 
-# If the script is being ran directly we will need to set the paths
+# Check if script is being ran frmo the install media
 if [ -d /tmp/frzr_root ]; then
     
     if [ -d "${SUBVOL}" ]; then
@@ -45,20 +45,22 @@ EOF
 else
     echo "We don't appear to be running from an arch install media"
 fi
+
+
 # Build initramfs from within a deployed system
 if [ -d /frzr_root ]; then
 
-if [ -n "$SUBVOL" ]; then
-    ### Get Distro version and build from $SUBVOL/etc/os-release
-    ID=$(grep '^ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
-    VERSIONID=$(grep '^VERSION_ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
-    BUILDID=$(grep '^BUILD_ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
-else
-    ### Get Distro version and build from /etc/os-release
-    ID=$(grep '^ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
-    VERSIONID=$(grep '^VERSION_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
-    BUILDID=$(grep '^BUILD_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
-fi
+    if [ -n "$SUBVOL" ]; then
+        ### Grabbing name of the new deployed system
+        ID=$(grep '^ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
+        VERSIONID=$(grep '^VERSION_ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
+        BUILDID=$(grep '^BUILD_ID=' "$SUBVOL/etc/os-release" | awk -F= '{ print $2 }' | sed 's/"//g')
+    else
+        ### Grabbing name of the currently deployed system
+        ID=$(grep '^ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
+        VERSIONID=$(grep '^VERSION_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
+        BUILDID=$(grep '^BUILD_ID=' /etc/os-release | awk -F= '{ print $2 }' | sed 's/"//g')
+    fi
 
     BUILD="$ID"-"$VERSIONID"_"$BUILDID"
     DEPLOYMENT_PATH="/frzr_root/deployments/$BUILD"
@@ -73,7 +75,7 @@ fi
         echo "Filesystem appears to be unlocked"
     fi
     
-    echo $BUILD
+    echo "Generating configuration for $BUILD"
 
     ### Create distro mkinitcpio preset
     echo '

--- a/frzr-initramfs
+++ b/frzr-initramfs
@@ -7,22 +7,6 @@ fi
 
 # If the script is being ran directly we will need to set the paths
 if [ -d /tmp/frzr_root ]; then
-    export MOUNT_PATH=$1
-    export SUBVOL=$2
-    export NAME=$3
-    
-    # Checking paths
-    echo "Checking installion info..."
-    echo "Root Mount:${MOUNT_PATH}"
-    echo "Subvolume Mount:${SUBVOL}"
-    echo "Deployment Name:${NAME}"
-else
-    # This is for running frzr-initramfs from the deployed system itself without frzr-deploy
-    export MOUNT_PATH=""
-    export SUBVOL=""
-fi
-
-if [ -d /tmp/frzr_root ]; then
     
     if [ -d "${SUBVOL}" ]; then
         

--- a/frzr-tweaks
+++ b/frzr-tweaks
@@ -18,12 +18,6 @@ else
     echo "Checking for device-quirks"
     if [ -e "/usr/share/device-quirks/id-device" ]; then
         /usr/share/device-quirks/id-device
-        RESULT=$?
-        # Check if we received the signal to rebuild initramfs
-        if [ ${RESULT} == "0" ]; then
-           echo "Signal recieved to rebuild initramfs"
-           /usr/bin/frzr-initramfs
-        fi
     else
         echo "Device-quirks packages was not found, skipping..."
     fi

--- a/frzr-tweaks
+++ b/frzr-tweaks
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+if [ $EUID -ne 0 ]; then
+    echo "$(basename $0) must be run as root"
+    exit 1
+fi
+
+# If the script is being ran directly we will need to set the paths
+if [ -d /tmp/frzr_root ]; then
+    export MOUNT_PATH=$1
+    export SUBVOL=$2
+    export NAME=$3
+    
+    # Checking paths
+    echo "Checking installion info..."
+    echo "Root Mount:${MOUNT_PATH}"
+    echo "Subvolume Mount:${SUBVOL}"
+    echo "Deployment Name:${NAME}"
+else
+    # This is for running frzr-initramfs from the deployed system itself without frzr-deploy
+    export MOUNT_PATH=""
+    export SUBVOL=""
+fi
+
+# Check device ID and see if any quirks exist in the new image being deployed
+if [ -e ${SUBVOL}/usr/share/device-quirks/id-device ]; then
+    ${SUBVOL}/usr/share/device-quirks/id-device
+    RESULT=$?
+    # If we don't see what were looking for in the new image, then check the current system as the last resort
+    elif [ -e "/etc/device-quirks/id-device" ]; then
+    /etc/device-quirks/id-device
+    RESULT=$?
+    # This will happen if the device quirks package is not installed, exit gracefully
+else
+    echo "Unable to run id-device to determine if quirks need to be applied"
+    exit 0
+fi

--- a/frzr-tweaks
+++ b/frzr-tweaks
@@ -6,7 +6,7 @@ if [ $EUID -ne 0 ]; then
 fi
 
 # Check if device quirks exist in the new image when frzr-deploy is used
-if [ -v ${SUBVOL} ]; then
+if [ -v SUBVOL ]; then
     echo "Checking newly deployed system for device-quirks"
     if [ -e "${SUBVOL}/usr/share/device-quirks/id-device" ]; then
         ${SUBVOL}/usr/share/device-quirks/id-device

--- a/frzr-tweaks
+++ b/frzr-tweaks
@@ -5,33 +5,26 @@ if [ $EUID -ne 0 ]; then
     exit 1
 fi
 
-# If the script is being ran directly we will need to set the paths
-if [ -d /tmp/frzr_root ]; then
-    export MOUNT_PATH=$1
-    export SUBVOL=$2
-    export NAME=$3
-    
-    # Checking paths
-    echo "Checking installion info..."
-    echo "Root Mount:${MOUNT_PATH}"
-    echo "Subvolume Mount:${SUBVOL}"
-    echo "Deployment Name:${NAME}"
-else
-    # This is for running frzr-initramfs from the deployed system itself without frzr-deploy
-    export MOUNT_PATH=""
-    export SUBVOL=""
-fi
-
-# Check device ID and see if any quirks exist in the new image being deployed
-if [ -e ${SUBVOL}/usr/share/device-quirks/id-device ]; then
-    ${SUBVOL}/usr/share/device-quirks/id-device
-    RESULT=$?
-    if [ "$RESULT" -eq 0 -a -z "{$SUBVOL}" ]; then
-        /usr/bin/frzr-initramfs
+# Check if device quirks exist in the new image when frzr-deploy is used
+if [ -v ${SUBVOL} ]; then
+    echo "Checking newly deployed system for device-quirks"
+    if [ -e "${SUBVOL}/usr/share/device-quirks/id-device" ]; then
+        ${SUBVOL}/usr/share/device-quirks/id-device
+    else
+        echo "Device-quirks package was not found, skipping..."
     fi
-    
-    # This will happen if the device quirks package is not installed, exit gracefully
 else
-    echo "Unable to run id-device to determine if quirks need to be applied"
-    exit 0
+# Check if device quirks exist when frzr-tweaks is ran directly
+    echo "Checking for device-quirks"
+    if [ -e "/usr/share/device-quirks/id-device" ]; then
+        /usr/share/device-quirks/id-device
+        RESULT=$?
+        # Check if we received the signal to rebuild initramfs
+        if [ ${RESULT} == "0" ]; then
+           echo "Signal recieved to rebuild initramfs"
+           /usr/bin/frzr-initramfs
+        fi
+    else
+        echo "Device-quirks packages was not found, skipping..."
+    fi
 fi


### PR DESCRIPTION
The proposed changes will build the initramfs each time frzr-deploy is ran using a custom chimeraos.preset for mkinitcpio. This allows us to use commands like `mkinitcpio -P` to rebuild the initramfs whenever necessary during install or whenever frzr-initramfs is used. 

This also adds frzr-tweaks that currently is being used to trigger the device-quirks scripts that automatically will set up handheld devices and if a config exists at `/etc/device-quirks.conf` the user can opt into firmware overrides to fix problems and/or add functionality to the device, ie 40hz refresh rate.

This will also allow us to provide DSDT fixes for handhelds that have bad ACPI/DSDT firmware on them to fix devices like the Air Plus where the IRQ for the i8042 keyboard is broke.

Users will be able to run device-quirks without unlocking by running `sudo frzr-tweaks` at any time if the config at `/etc/device-quirks` is created.

This will need to be tested with fresh installs, upgrades, and in unlocked/locked states to ensure we don't create any unexpected behavior.