### PR TITLE
Lazy umount to fix error messages

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -308,7 +308,7 @@ main() {
 
 	echo "deployment complete; restart to boot into ${NAME}"
 
-	umount -R ${MOUNT_PATH}
+	umount -R -l ${MOUNT_PATH}
 }
 
 


### PR DESCRIPTION
Some devices like the OXP mini will throw an update error because the umount command fails, I'm not entirely sure why and it does not happen on other hardware.