### PR TITLE
Support microcode hook

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -364,7 +364,7 @@ main() {
 	if grep -q "microcode" "/etc/mkinitcpio.conf"; then
 		echo "microcode hook present: will skip systemd-boot initrd."
 
-		AMD_UCODE="# intel-ucode in initramfs"
+		AMD_UCODE="# amd-ucode in initramfs"
 		INTEL_UCODE="# intel-ucode in initramfs"
 	else
 		echo "microcode hook not found: will use systemd-bood initrd."

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -337,7 +337,7 @@ main() {
 
 		AMD_UCODE="# intel-ucode in initramfs"
 		INTEL_UCODE="# intel-ucode in initramfs"
-	elif
+	else
 		echo "microcode hook not found: will use systemd-bood initrd.\n"
 
 		if [ -e ${SUBVOL}/boot/amd-ucode.img ] ; then

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -332,13 +332,13 @@ main() {
 	AMD_UCODE="# missing intel-ucode"
 	INTEL_UCODE="# missing intel-ucode"
 
-	if grep -q "microcode" "${DEPLOY_PATH}/etc/mkinitcpio.conf"; then
+	if grep -q "microcode" "${MOUNT_PATH}/etc/mkinitcpio.conf"; then
 		echo "microcode hook present: will skip systemd-boot initrd."
 
 		AMD_UCODE="# intel-ucode in initramfs"
 		INTEL_UCODE="# intel-ucode in initramfs"
 	else
-		echo "microcode hook not found: will use systemd-bood initrd.\n"
+		echo "microcode hook not found: will use systemd-bood initrd."
 
 		if [ -e ${SUBVOL}/boot/amd-ucode.img ] ; then
 			cp ${SUBVOL}/boot/amd-ucode.img ${MOUNT_PATH}/boot/${NAME}

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -329,36 +329,6 @@ main() {
 	cp ${SUBVOL}/boot/vmlinuz-linux ${MOUNT_PATH}/boot/${NAME}
 	cp ${SUBVOL}/boot/initramfs-linux.img ${MOUNT_PATH}/boot/${NAME}
 
-	AMD_UCODE="# missing intel-ucode"
-	INTEL_UCODE="# missing intel-ucode"
-
-	if grep -q "microcode" "${MOUNT_PATH}/etc/mkinitcpio.conf"; then
-		echo "microcode hook present: will skip systemd-boot initrd."
-
-		AMD_UCODE="# intel-ucode in initramfs"
-		INTEL_UCODE="# intel-ucode in initramfs"
-	else
-		echo "microcode hook not found: will use systemd-bood initrd."
-
-		if [ -e ${SUBVOL}/boot/amd-ucode.img ] ; then
-			cp ${SUBVOL}/boot/amd-ucode.img ${MOUNT_PATH}/boot/${NAME}
-			AMD_UCODE="initrd /${NAME}/amd-ucode.img"
-		fi
-		
-		if [ -e ${SUBVOL}/boot/intel-ucode.img ] ; then
-			cp ${SUBVOL}/boot/intel-ucode.img ${MOUNT_PATH}/boot/${NAME}
-			INTEL_UCODE="initrd /${NAME}/intel-ucode.img"
-		fi
-	fi
-
-	ADDITIONAL_ARGUMENTS=""
-	if [ -e ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf ] ; then
-		ADDITIONAL_ARGUMENTS="$ADDITIONAL_ARGUMENTS $(cat ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf)"
-	fi
-
-	get_boot_cfg "${NAME}" "${AMD_UCODE}" "${INTEL_UCODE}" "${ADDITIONAL_ARGUMENTS}" > ${BOOT_CFG}
-	echo "default frzr.conf" > ${MOUNT_PATH}/boot/loader/loader.conf
-
 	# Check if there are migrations available
 	if compgen -G "${SUBVOL}"/usr/lib/frzr.d/*.migration > /dev/null ; then
 		for m in "${SUBVOL}"/usr/lib/frzr.d/*.migration ;
@@ -387,6 +357,37 @@ main() {
 
 	# Run frzr-initramfs to create mkinicpio.conf and build an initramfs
 	frzr-initramfs
+
+	# now that the initramfs has been built determine if that includes microcode
+	AMD_UCODE="# missing intel-ucode"
+	INTEL_UCODE="# missing intel-ucode"
+	if grep -q "microcode" "/etc/mkinitcpio.conf"; then
+		echo "microcode hook present: will skip systemd-boot initrd."
+
+		AMD_UCODE="# intel-ucode in initramfs"
+		INTEL_UCODE="# intel-ucode in initramfs"
+	else
+		echo "microcode hook not found: will use systemd-bood initrd."
+
+		if [ -e ${SUBVOL}/boot/amd-ucode.img ] ; then
+			cp ${SUBVOL}/boot/amd-ucode.img ${MOUNT_PATH}/boot/${NAME}
+			AMD_UCODE="initrd /${NAME}/amd-ucode.img"
+		fi
+		
+		if [ -e ${SUBVOL}/boot/intel-ucode.img ] ; then
+			cp ${SUBVOL}/boot/intel-ucode.img ${MOUNT_PATH}/boot/${NAME}
+			INTEL_UCODE="initrd /${NAME}/intel-ucode.img"
+		fi
+	fi
+
+	ADDITIONAL_ARGUMENTS=""
+	if [ -e ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf ] ; then
+		ADDITIONAL_ARGUMENTS="$ADDITIONAL_ARGUMENTS $(cat ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf)"
+	fi
+
+	# write down the kernel cmdline as the last step: shall a blackout happen the prevous deployment will get booted
+	get_boot_cfg "${NAME}" "${AMD_UCODE}" "${INTEL_UCODE}" "${ADDITIONAL_ARGUMENTS}" > ${BOOT_CFG}
+	echo "default frzr.conf" > ${MOUNT_PATH}/boot/loader/loader.conf
 
 	rm -f ${MOUNT_PATH}/*.img.*
 

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -329,16 +329,26 @@ main() {
 	cp ${SUBVOL}/boot/vmlinuz-linux ${MOUNT_PATH}/boot/${NAME}
 	cp ${SUBVOL}/boot/initramfs-linux.img ${MOUNT_PATH}/boot/${NAME}
 
-	AMD_UCODE=""
-	if [ -e ${SUBVOL}/boot/amd-ucode.img ] ; then
-		cp ${SUBVOL}/boot/amd-ucode.img ${MOUNT_PATH}/boot/${NAME}
-		AMD_UCODE="initrd /${NAME}/amd-ucode.img"
-	fi
+	AMD_UCODE="# missing intel-ucode"
+	INTEL_UCODE="# missing intel-ucode"
 
-	INTEL_UCODE=""
-	if [ -e ${SUBVOL}/boot/intel-ucode.img ] ; then
-		cp ${SUBVOL}/boot/intel-ucode.img ${MOUNT_PATH}/boot/${NAME}
-		INTEL_UCODE="initrd /${NAME}/intel-ucode.img"
+	if grep -q "microcode" "${DEPLOY_PATH}/etc/mkinitcpio.conf"; then
+		echo "microcode hook present: will skip systemd-boot initrd."
+
+		AMD_UCODE="# intel-ucode in initramfs"
+		INTEL_UCODE="# intel-ucode in initramfs"
+	elif
+		echo "microcode hook not found: will use systemd-bood initrd.\n"
+
+		if [ -e ${SUBVOL}/boot/amd-ucode.img ] ; then
+			cp ${SUBVOL}/boot/amd-ucode.img ${MOUNT_PATH}/boot/${NAME}
+			AMD_UCODE="initrd /${NAME}/amd-ucode.img"
+		fi
+		
+		if [ -e ${SUBVOL}/boot/intel-ucode.img ] ; then
+			cp ${SUBVOL}/boot/intel-ucode.img ${MOUNT_PATH}/boot/${NAME}
+			INTEL_UCODE="initrd /${NAME}/intel-ucode.img"
+		fi
 	fi
 
 	ADDITIONAL_ARGUMENTS=""

--- a/frzr-initramfs
+++ b/frzr-initramfs
@@ -97,7 +97,6 @@ if [ -d /frzr_root ]; then
 echo '
 ALL_config="/etc/mkinitcpio.conf"
 ALL_kver="/boot/vmlinuz-linux"
-ALL_microcode=(/boot/*-ucode.img)
 
 PRESETS="default"
 
@@ -115,7 +114,6 @@ EOF
        echo '
 ALL_config="/etc/mkinitcpio.conf"
 ALL_kver="/boot/'$BUILD'/vmlinuz-linux"
-ALL_microcode=(/boot/'$BUILD'/*-ucode.img)
 
 PRESETS="default"
 


### PR DESCRIPTION
Since February 2024 archlinux deprecated the usage of addending ucode initrd into bootloader configuration files such as
```
initrd /amd-ucode.img
initrd /intel-ucode.img
```

since those are included in the initramfs when mkinitcpio is run.

This PR scans /etc/mkinitcpio.conf (the same file that was used to generate the initramfs) and checks for microcode hook:
if said hook is present entries in the systemd-boot configuration are not added.

This ensures end-user deployments are not using deprecated boot method.