### PR TITLE
Make /etc a subvolume that needs no mounting

### DIFF
--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -330,9 +330,17 @@ main() {
 	else
 		echo "System image ${NAME} will use an /etc subvolume"
 
+		# unlock the subvolume to be able to create a nested subvolume
+		btrfs property set -f -ts "${SUBVOL}/" ro false
+
+		# create the nested subvolume for /etc
 		btrfs subvolume create "${SUBVOL}/etc"
 
+		# create the nested subvolume for /snapshots
 		btrfs subvolume create "${SUBVOL}/snapshots"
+
+		# re-lock the subvolume. ${SUBVOL}/etc will remain R/W
+		btrfs property set -f -ts "${SUBVOL}/" ro true
 
 		btrfs subvolume create "${SUBVOL}/snapshots/etc"
 

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -337,7 +337,7 @@ main() {
 		btrfs subvolume create "${SUBVOL}/snapshots/etc"
 
 		# copy every stock /etc (that has been moved to /usr/etc) file to the actual /etc
-		cp -a ${SUBVOL}/usr/etc/** ${SUBVOL}/etc/
+		cp -a ${SUBVOL}/usr/etc/* ${SUBVOL}/etc/
 
 		# copy the machine-id file: this was created by systemd the very first boot and identify the machine:
 		# changing this will also make ssh warn about machine not matching.

--- a/__frzr-deploy
+++ b/__frzr-deploy
@@ -325,6 +325,32 @@ main() {
 		tar xfO ${IMG_FILE} | btrfs receive --quiet ${DEPLOY_PATH}
 	fi
 
+	if [ -d "${SUBVOL}/etc" ]; then
+		echo "System image ${NAME} will use the /etc overlay"
+	else
+		echo "System image ${NAME} will use an /etc subvolume"
+
+		btrfs subvolume create "${SUBVOL}/etc"
+
+		btrfs subvolume create "${SUBVOL}/snapshots"
+
+		btrfs subvolume create "${SUBVOL}/snapshots/etc"
+
+		# copy every stock /etc (that has been moved to /usr/etc) file to the actual /etc
+		cp -a ${SUBVOL}/usr/etc/** ${SUBVOL}/etc/
+
+		# copy the machine-id file: this was created by systemd the very first boot and identify the machine:
+		# changing this will also make ssh warn about machine not matching.
+		if [ -f "/etc/machine-id" ]; then
+			cp -a /etc/machine-id ${SUBVOL}/etc/
+		else
+			echo "WARNING: no /etc/machine-id -- new machine-id will be regenerated at next boot"
+		fi
+
+		# Make a snapshot of /etc so that this state can be restored
+		btrfs subvolume snapshot ${SUBVOL}/etc ${SUBVOL}/snapshots/etc/0
+	fi
+
 	mkdir -p ${MOUNT_PATH}/boot/${NAME}
 	cp ${SUBVOL}/boot/vmlinuz-linux ${MOUNT_PATH}/boot/${NAME}
 	cp ${SUBVOL}/boot/initramfs-linux.img ${MOUNT_PATH}/boot/${NAME}


### PR DESCRIPTION
This is meant to solve the /etc mounting issue where the /etc overlay fires off some race conditions with the system loading resulting in the infamous "gamer is not the password".

This also deals with the overlays that prevents chimeraos team to effectively distribute updates that needs /etc changes.